### PR TITLE
Update seaget.py

### DIFF
--- a/wip/seaget.py
+++ b/wip/seaget.py
@@ -26,9 +26,9 @@ except ImportError:
 def main():
     args = get_arguments()
     see = SeaGet(args.baud, args.cont, args.filename, args.device, args.new_baud)
-    if args.dumptype=='memory':
+    if str(args.dumptype)=="['memory']":
         see.dump_memory(args.filename, args.cont)
-    elif args.dumptype=='buffer':
+    elif str(args.dumptype)=="['buffer']":
         see.dump_buffer(args.filename, args.cont)
 
 def get_arguments():


### PR DESCRIPTION
args.dumptype is a list object and cannot be compared with a string, or at least it wasn't working on my machine until I did this fix.

also when converting args.dumptype to a string using 'str' it added the square brackets and the single quotes around the word so it became like this ['memory'], that is why I added the double quotes.